### PR TITLE
Target both revamped and legacy Twin Boar

### DIFF
--- a/GameData/WaterfallRestock/Patches/Squad/liquidEngineTwinBoar.cfg
+++ b/GameData/WaterfallRestock/Patches/Squad/liquidEngineTwinBoar.cfg
@@ -1,6 +1,6 @@
 
 
-@PART[Size2LFB]:AFTER[ReStock]
+@PART[Size2LFB,Size2LFB_v2]:AFTER[ReStock]
 {
 
   !EFFECTS {}


### PR DESCRIPTION
Quick fix to target the KSP 1.11 version of the Twin Boar as well as the older version. In-game testing seems to work without issue.

Fixes #11 