### PR TITLE
Fix for missing plume on Schnauzer

### DIFF
--- a/GameData/WaterfallRestock/Patches/RestockPlus/RestockPlusSchnauzer.cfg
+++ b/GameData/WaterfallRestock/Patches/RestockPlus/RestockPlusSchnauzer.cfg
@@ -80,9 +80,9 @@
     TEMPLATE
     {
       // This is the name of the template to use
-      templateName = waterfall-kerolox-upper-2
+      templateName = waterfall-hypergolic-aerozine50-upper-1
       // This field allows you to override the parentTransform name in the EFFECTS contained in the template
-      overrideParentTransform = waterfall-hypergolic-aerozine50-upper-1
+      overrideParentTransform = thrustTransform
      position = 0,0,0.23
 rotation = 0, 0, 0
 scale = 1, 1, 0.9


### PR DESCRIPTION
The Schnauzer's plume is currently broken (missing). [The changes made to its config in this commit](https://github.com/post-kerbin-mining-corporation/WaterfallRestock/commit/ca74add3417cb0a2146a91fe8bf086522a4da307#diff-039c99924418690ad18c50dd730309191801b3026f816f60b2dba9781304fae0) look very suspicious, and I suspect its `overrideParentTransform` was accidentally changed instead of `templateName` as intended. This fix seems to work and also makes the Schnauzer match its Making History equivalent, the [Wolfhound](https://github.com/post-kerbin-mining-corporation/WaterfallRestock/blob/master/GameData/WaterfallRestock/Patches/Squad/LiquidEngineRE-J10.cfg#L94).