### PR TITLE
Add Bobcat, Cheetah, Dart, Thud, jet engine configs & templates

### DIFF
--- a/GameData/WaterfallRestock/Patches/Squad/jetEngines.cfg
+++ b/GameData/WaterfallRestock/Patches/Squad/jetEngines.cfg
@@ -1,0 +1,467 @@
+// J-20 "Juno" Basic Jet Engine
+@PART[miniJetEngine]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{ 
+  // Deleting stock smoke/contrail effect
+	@EFFECTS
+	{		
+		@running_thrust
+		{			
+			!PREFAB_PARTICLE {}					
+		}
+	}
+
+  MODULE
+  {
+    name = ModuleWaterfallFX
+		// This is a custom name
+    moduleID = JetJunoFX
+		// This links the effects to a given ModuleEngines
+    engineID = Cruise
+    version = FixedRampRates
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    ATMOSPHEREDENSITYCONTROLLER
+    {
+      name = atmosphereDepth
+    }
+    // This controller scales with effective throttle
+    THROTTLECONTROLLER
+    {
+      responseRateUp = 100
+      responseRateDown = 100
+      engineID = Cruise
+      name = throttle
+    }
+    // This controller generates a random value in the range specified
+    RANDOMNESSCONTROLLER
+    {
+      range = -1,1
+      noiseType = random
+      randomSeed = False
+      seed = 0
+      scale = 1
+      minimum = 0
+      speed = 1
+      name = random
+    }
+    // This controller scales with speed in mach
+    MACHCONTROLLER
+    {
+      name = mach
+    }
+    // This controller outputs a 1 or 0 depending on the engine on/off state, including flameout
+    ENGINEONOFFCONTROLLER
+    {
+      engineID = Cruise
+      responseRateUp = 0.3
+      responseRateDown = 0.3
+      name = engineOn
+    }
+    // This controller is linked to thrust reverser deployment
+    // SCALARMODULECONTROLLER
+    // {
+    //  moduleID = genericAnim
+    //  name = reverser
+    // }
+    
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-jet-standard-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = thrustPoint
+      position = 0,0.3,0
+      rotation = -90, 0, 0
+      scale = 0.25, 0.25, 0.5
+    }
+  }
+}
+
+// J-33 "Wheesley" Turbofan Engine
+@PART[JetEngine]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{ 
+  // Deleting stock smoke/contrail effect
+	@EFFECTS
+	{		
+		@running_thrust
+		{			
+			!PREFAB_PARTICLE {}					
+		}
+	}
+
+  MODULE
+  {
+    name = ModuleWaterfallFX
+		// This is a custom name
+    moduleID = JetWheesleyFX
+		// This links the effects to a given ModuleEngines
+    engineID = Cruise
+    version = FixedRampRates
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    ATMOSPHEREDENSITYCONTROLLER
+    {
+      name = atmosphereDepth
+    }
+    // This controller scales with effective throttle
+    THROTTLECONTROLLER
+    {
+      responseRateUp = 100
+      responseRateDown = 100
+      engineID = Cruise
+      name = throttle
+    }
+    // This controller generates a random value in the range specified
+    RANDOMNESSCONTROLLER
+    {
+      range = -1,1
+      noiseType = random
+      randomSeed = False
+      seed = 0
+      scale = 1
+      minimum = 0
+      speed = 1
+      name = random
+    }
+    // This controller scales with speed in mach
+    MACHCONTROLLER
+    {
+      name = mach
+    }
+    // This controller outputs a 1 or 0 depending on the engine on/off state, including flameout
+    ENGINEONOFFCONTROLLER
+    {
+      engineID = Cruise
+      responseRateUp = 0.25
+      responseRateDown = 0.25
+      name = engineOn
+    }
+    // This controller is linked to thrust reverser deployment
+    SCALARMODULECONTROLLER
+    {
+      moduleID = genericAnim
+      name = reverser
+    }
+    
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-jet-standard-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = smokePoint
+      position = 0, 0, -0.8
+      rotation = 0, 0, 0
+      scale = 0.6, 0.6, 1.0
+    }
+  }
+}
+
+// J-90 "Goliath" Turbofan Engine
+@PART[turboFanSize2]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{ 
+  // Deleting stock smoke/contrail effect
+	@EFFECTS
+	{		
+		@running_thrust
+		{			
+			!PREFAB_PARTICLE {}					
+		}
+	}
+
+  MODULE
+  {
+    name = ModuleWaterfallFX
+		// This is a custom name
+    moduleID = JetGoliathFX
+		// This links the effects to a given ModuleEngines
+    engineID = Cruise
+    version = FixedRampRates
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    ATMOSPHEREDENSITYCONTROLLER
+    {
+      name = atmosphereDepth
+    }
+    // This controller scales with effective throttle
+    THROTTLECONTROLLER
+    {
+      responseRateUp = 100
+      responseRateDown = 100
+      engineID = Cruise
+      name = throttle
+    }
+    // This controller generates a random value in the range specified
+    RANDOMNESSCONTROLLER
+    {
+      range = -1,1
+      noiseType = random
+      randomSeed = False
+      seed = 0
+      scale = 1
+      minimum = 0
+      speed = 1
+      name = random
+    }
+    // This controller scales with speed in mach
+    MACHCONTROLLER
+    {
+      name = mach
+    }
+    // This controller outputs a 1 or 0 depending on the engine on/off state, including flameout
+    ENGINEONOFFCONTROLLER
+    {
+      engineID = Cruise
+      responseRateUp = 0.1
+      responseRateDown = 0.1
+      name = engineOn
+    }
+    // This controller is linked to thrust reverser deployment
+    SCALARMODULECONTROLLER
+    {
+      moduleID = genericAnim
+      name = reverser
+    }
+    
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-jet-standard-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = smokePoint
+      position = 0, -0.04, -1.5
+      rotation = 0, 0, 0
+      scale = 1.3, 1.3, 2.0
+    }
+  }
+}
+
+// J-404 "Panther" Afterburning Turbofan
+@PART[turboJet]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{
+  // Deleting stock plume effects
+  @EFFECTS
+  {
+    @running_dry { !PREFAB_PARTICLE {} }
+    @running_wet { !PREFAB_PARTICLE {} }
+    @power_wet { !MODEL_MULTI_PARTICLE {} }
+  }
+
+  // Waterfall effects -- dry running operation
+  MODULE
+  {
+    name = ModuleWaterfallFX
+		// This is a custom name
+    moduleID = JetPantherFX-Dry
+		// This links the effects to a given ModuleEngines
+    engineID = Dry
+    version = FixedRampRates
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    ATMOSPHEREDENSITYCONTROLLER
+    {
+      name = atmosphereDepth
+    }
+    // This controller scales with effective throttle
+    THROTTLECONTROLLER
+    {
+      responseRateUp = 100
+      responseRateDown = 100
+      engineID = Dry
+      name = throttle
+    }
+    // This controller generates a random value in the range specified
+    RANDOMNESSCONTROLLER
+    {
+      range = -1,1
+      noiseType = random
+      randomSeed = False
+      seed = 0
+      scale = 1
+      minimum = 0
+      speed = 1
+      name = random
+    }
+    // This controller scales with speed in mach
+    MACHCONTROLLER
+    {
+      name = mach
+    }
+    // This controller outputs a 1 or 0 depending on the engine on/off state, including flameout
+    ENGINEONOFFCONTROLLER
+    {
+      engineID = Dry
+      responseRateUp = 0.5
+      responseRateDown = 0.5
+      name = engineOn
+    }
+    
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-jet-standard-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = thrustTransform
+      position = 0, 0, 0
+      rotation = 0, 0, 0
+      scale = 0.5, 0.5, 1.5
+    }
+  }
+
+  // Waterfall effects -- wet/afterburner running operation
+  MODULE
+  {
+    name = ModuleWaterfallFX
+		// This is a custom name
+    moduleID = JetPantherFX-Wet
+		// This links the effects to a given ModuleEngines
+    engineID = Wet
+    version = FixedRampRates
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    ATMOSPHEREDENSITYCONTROLLER
+    {
+      name = atmosphereDepth
+    }
+    // This controller scales with effective thrust
+    // This allows for the plume to respond to e.g. an air-starved engine
+    THRUSTCONTROLLER
+    {
+      engineID = Wet
+      name = throttle
+    }
+    // This controller generates a random value in the range specified
+    RANDOMNESSCONTROLLER
+    {
+      range = -1,1
+      noiseType = random
+      randomSeed = False
+      seed = 0
+      scale = 1
+      minimum = 0
+      speed = 1
+      name = random
+    }
+    // This controller scales with speed in mach
+    MACHCONTROLLER
+    {
+      name = mach
+    }
+    // This controller outputs a 1 or 0 depending on the engine on/off state, including flameout
+    ENGINEONOFFCONTROLLER
+    {
+      engineID = Wet
+      responseRateUp = 0.5
+      responseRateDown = 0.5
+      name = engineOn
+    }
+    
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-jet-afterburner-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = thrustTransform
+      position = 0, 0, 0
+      rotation = 0, 0, 0
+      scale = 0.6, 0.6, 1.2
+    }
+  }
+}
+
+// J-X4 "Whiplash" Afterburning Turbofan
+@PART[turboFanEngine]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{
+  // Deleting stock plume effects
+  @EFFECTS
+	{		
+		@running_thrust { !PREFAB_PARTICLE {}	}
+    !shockDiamond {}
+    @running_turbine { !MODEL_MULTI_PARTICLE{} }
+	}
+
+  // Waterfall effects
+  MODULE
+  {
+    name = ModuleWaterfallFX
+		// This is a custom name
+    moduleID = JetWhiplashFX
+		// This links the effects to a given ModuleEngines
+    // engineID = Whiplash
+    version = FixedRampRates
+
+    // List out all controllers we want available
+    // This controller scales with atmosphere depth
+    ATMOSPHEREDENSITYCONTROLLER
+    {
+      name = atmosphereDepth
+    }
+    // This controller scales with effective thrust
+    // This allows for the plume to respond to e.g. an air-starved engine
+    THRUSTCONTROLLER
+    {
+      responseRateUp = 100
+      responseRateDown = 100
+      engineID = Cruise
+      name = throttle
+    }
+    // This controller generates a random value in the range specified
+    RANDOMNESSCONTROLLER
+    {
+      range = -1,1
+      noiseType = random
+      randomSeed = False
+      seed = 0
+      scale = 1
+      minimum = 0
+      speed = 1
+      name = random
+    }
+    // This controller scales with speed in mach
+    MACHCONTROLLER
+    {
+      name = mach
+    }
+    // This controller outputs a 1 or 0 depending on the engine on/off state, including flameout
+    ENGINEONOFFCONTROLLER
+    {
+      engineID = Whiplash
+      responseRateUp = 0.5
+      responseRateDown = 0.5
+      name = engineOn
+    }
+    
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-jet-afterburner-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = thrustTransform
+      position = 0, 0, 0
+      rotation = 0, 0, 0
+      scale = 0.9, 0.9, 0.9
+    }
+  }
+}

--- a/GameData/WaterfallRestock/Patches/Squad/liquidEngineDart.cfg
+++ b/GameData/WaterfallRestock/Patches/Squad/liquidEngineDart.cfg
@@ -1,0 +1,90 @@
+// T-1 Toroidal Aerospike "Dart" Liquid Fuel Engine
+@PART[toroidalAerospike]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{	
+	!MODULE[ModuleWaterfallFX] {}
+  !EFFECTS {}
+	!MODULE[EngineLightEffect] {}
+
+	EFFECTS
+  {
+    engage
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_vent_medium
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    flameout
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_explosion_low
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    fx-dart-running
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_rocket_hard
+        volume = 0.0 0.0
+        volume = 1.0 1.0
+        pitch = 0.0 0.2
+        pitch = 2.0 2.0
+        loop = true
+      }
+    }
+  }
+
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = toroidalAerospikeFX
+		// This links the effects to a given ModuleEngines
+		engineID = toroidalAerospike
+
+		// List out all controllers we want available
+    // This controller scales with atmosphere depth
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    // This controller scales with effective throttle
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+    }
+    // this controller generates a random value in the range specified
+    CONTROLLER
+    {
+      name = random
+      linkedTo = random
+      range = -1, 1
+		}
+
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-lower-3
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = thrustTransform
+      position = 0,0,-0.32
+      rotation = 0, 0, 0
+      scale = 0.58, 0.58, 0.65
+    }
+	}
+}

--- a/GameData/WaterfallRestock/Patches/Squad/liquidEngineMH-1875.cfg
+++ b/GameData/WaterfallRestock/Patches/Squad/liquidEngineMH-1875.cfg
@@ -1,0 +1,207 @@
+// LV-T91 "Cheetah" Liquid Fuel Engine
+@PART[LiquidEngineLV-T91]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{
+	!MODULE[ModuleWaterfallFX] {}
+  !EFFECTS {}
+	!MODULE[EngineLightEffect] {}
+
+	EFFECTS
+  {
+    engage
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_vent_medium
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    flameout
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_explosion_low
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    fx-cheetah-running
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_rocket_hard
+        volume = 0.0 0.0
+        volume = 0.01 0.2
+        volume = 1.0 0.8
+        pitch = 0.0 0.1
+        pitch = 0.01 0.2
+        pitch = 1.0 0.7
+        loop = true
+			}
+    }
+  }
+
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = LiquidEngineLV-T91FX
+		// This links the effects to a given ModuleEngines
+		engineID = LiquidEngineLV-T91
+
+		// List out all controllers we want available
+    // This controller scales with atmosphere depth
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    // This controller scales with effective throttle
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+    }
+    // this controller generates a random value in the range specified
+    CONTROLLER
+    {
+      name = random
+      linkedTo = random
+      range = -1, 1
+		}
+
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-upper-3
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = fxTransformPlume
+      position = 0, -0.13, 0
+      rotation = 90, 0, 0
+      scale = 1.62, 1.62, 1.62
+    }
+
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-vernier-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = vernier_fxTransform
+      position = 0, 0, -0.005
+      rotation = -90, 0, 0
+      scale = 2.3, 2.3, 2
+    }
+	}
+}
+
+// LV-TX87 "Bobcat" Liquid Fuel Engine
+@PART[LiquidEngineLV-TX87]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{
+	!MODULE[ModuleWaterfallFX] {}
+  !EFFECTS {}
+	!MODULE[EngineLightEffect] {}
+
+	  EFFECTS
+  {
+    engage
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_vent_medium
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    flameout
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_explosion_low
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    fx-bobcat-running
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_rocket_hard
+        volume = 0.0 0.0
+        volume = 0.01 0.2
+        volume = 1.0 0.8
+        pitch = 0.0 0.1
+        pitch = 0.01 0.2
+        pitch = 1.0 0.5
+        loop = true
+      }
+    }
+  }
+
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = LiquidEngineLV-TX87FX
+		// This links the effects to a given ModuleEngines
+		engineID = LiquidEngineLV-TX87
+
+		// List out all controllers we want available
+    // This controller scales with atmosphere depth
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    // This controller scales with effective throttle
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+    }
+    // this controller generates a random value in the range specified
+    CONTROLLER
+    {
+      name = random
+      linkedTo = random
+      range = -1, 1
+		}
+
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-lower-5
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = fxTransformPlume
+      position = 0, -0.05, 0
+      rotation = 90, 0, 0
+      scale = 1.28, 1.28, 1.28
+    }
+
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-exhaust-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = exhaust_fxTransform
+      position = 0, 0, 0
+      rotation = 0, 0, 0
+      scale = 0.79, 0.8, 0.79
+    }
+	}
+}

--- a/GameData/WaterfallRestock/Patches/Squad/liquidEngineThud.cfg
+++ b/GameData/WaterfallRestock/Patches/Squad/liquidEngineThud.cfg
@@ -1,0 +1,101 @@
+// Mk-55 "Thud" Liquid Fuel Engine
+@PART[radialLiquidEngine1-2]:NEEDS[ReStock]:FOR[WaterfallRestock]
+{
+	!MODULE[ModuleWaterfallFX] {}
+ 	!EFFECTS {}
+	!MODULE[EngineLightEffect] {}
+
+	EFFECTS
+  {
+    engage
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_vent_medium
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    flameout
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_explosion_low
+        volume = 1.0
+        pitch = 2.0
+        loop = false
+      }
+    }
+    fx-thud-running
+    {
+      AUDIO
+      {
+        channel = Ship
+        clip = sound_rocket_hard
+        volume = 0.0 0.0
+        volume = 1.0 1.0
+        pitch = 0.0 0.2
+        pitch = 1.0 1.0
+        loop = true
+      }
+    }
+  }
+
+	MODULE
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = radialLiquidEngine1-2FX
+		// This links the effects to a given ModuleEngines
+		engineID = radialLiquidEngine1-2
+
+		// List out all controllers we want available
+    // This controller scales with atmosphere depth
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    // This controller scales with effective throttle
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+    }
+    // this controller generates a random value in the range specified
+    CONTROLLER
+    {
+      name = random
+      linkedTo = random
+      range = -1, 1
+		}
+
+    // -----------------------------------------------------
+    // Past here should be generated with the ingame editor!
+    // -----------------------------------------------------
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-lower-5
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = thrustTransform
+      position = 0, 0, 0.075
+      rotation = 0, 0, 0
+      scale = 0.76, 0.76, 0.6
+    }
+
+    TEMPLATE
+    {
+      // This is the name of the template to use
+      templateName = waterfall-kerolox-exhaust-1
+      // This field allows you to override the parentTransform name in the EFFECTS contained in the template
+      overrideParentTransform = exhaust_fxTransform
+      position = 0, 0, 0.002
+      rotation = -90, 0, 0
+      scale = 0.3, 0.3, 0.3
+    }
+	}
+}

--- a/GameData/WaterfallRestock/Templates/waterfall-jet-afterburner-1.cfg
+++ b/GameData/WaterfallRestock/Templates/waterfall-jet-afterburner-1.cfg
@@ -1,0 +1,1073 @@
+// Afterburner-style jet based off of Pratt & Whitney J58 (e.g. SR-71 Blackbird)
+// 
+// Supported controllers:
+//  - [atmosphereDepth] Atmosphere Density
+//  - [random] Randomness
+//  - [throttle] Throttle
+//  - [engineOn] Engine On State
+//  - [reverser] Scalar Module (AnimateGeneric)
+// 
+// by Kavaeric
+EFFECTTEMPLATE
+{
+	templateName = waterfall-jet-afterburner-1
+	EFFECT
+	{
+		name = plume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.100000001
+			rotationOffset = -90,0,0
+			scaleOffset = 1,5,1
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.811764717,0.253165483,0.0802657381,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.223529384,0.305668533,0.97647059,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.663398325
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.0396427102
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.13972843
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 2.37856317
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 15
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 60
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Symmetry
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SymmetryStrength
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0.069374755
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.221886992
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = -3.36963105
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tShockScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.6 0 0
+			}
+			yCurve
+			{
+				key = 0 0 0 0
+				key = 0.4 2 0 0
+				key = 1 3 0 0
+			}
+			zCurve
+			{
+				key = 0 0.6 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = randomz
+			randomnessScale = 0.100000001
+			name = BrightnessT
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.1 0 0 0
+				key = 0.3 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = BrightnessATM
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0.3 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = engineOn
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = engineOn
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.3 1 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _FresnelInvert
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tFresnel
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.2 0.4 0 0
+				key = 0.7 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _ExpandSquare
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tExpandSquare
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 -1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Noise
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tNoise
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0.5 1 0 0
+				key = 1 0.3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _ExpandLinear
+			controllerName = random
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = rFalloff
+			combinationType = ADD
+			floatCurve
+			{
+				key = 0 -0.1 0 0
+				key = 1 0.1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = distort
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 1,1,1
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Distortion (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _DistortionTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Blur
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Swirl
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Highlight
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Strength
+					value = 0.0500000007
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.5
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 47.4888229
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 40
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.0758332163
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 5
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tStrength
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.1 0 0
+				key = 1 0.2 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tScale
+			combinationType = REPLACE
+			xCurve
+			{
+				key = 0 0.6 0 0
+				key = 1 0.6 0 0
+			}
+			yCurve
+			{
+				key = 0 4 0 0
+				key = 1 15 0 0
+			}
+			zCurve
+			{
+				key = 0 0.6 0 0
+				key = 1 0.6 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0 0 0
+				key = 0.4 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aStrength
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.5 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = engineOn
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = engineOn
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = engineLight
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-point-light
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 1,1,1
+			LIGHT
+			{
+				intensity = 3
+				range = 8
+				color = 0.724317074,0.41495198,0.92592591,1
+				lightType = Point
+				angle = 0
+				transform = Light
+				baseTransform = 
+			}
+		}
+		LIGHTFLOATMODIFIER
+		{
+			floatName = Intensity
+			controllerName = throttle
+			transformName = Light
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBright
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 3 0 0
+			}
+		}
+		LIGHTFLOATMODIFIER
+		{
+			floatName = Intensity
+			controllerName = random
+			transformName = Light
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = rBright
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0.7 0 0
+				key = 1 1 0 0
+			}
+		}
+		LIGHTCOLORMODIFIER
+		{
+			colorName = _Main
+			controllerName = throttle
+			transformName = Light
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tColour
+			combinationType = MULTIPLY
+			rCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			gCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.6 1 0 0
+				key = 1 1 0 0
+			}
+			bCurve
+			{
+				key = 0 0 0 0
+				key = 0.6 1 0 0
+				key = 1 1 0 0
+			}
+			aCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shockPlume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-volumetric-cones
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 0.25,8,0.25
+			MATERIAL
+			{
+				transform = Waterfall/FX/fx-volumetric-cones(Clone)
+				shader = Waterfall/Additive Cones (Volumetric)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-katniss-noise-3-blurred
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.972549021,0.129629627,0.254901946,0.522222221
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.952941179,0.614973307,0.333333373,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFresnel
+					value = 2.18034983
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ConeLength
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.567588389
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 25
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _NoiseFresnel
+					value = 1.77658236
+				}
+				FLOAT
+				{
+					floatName = _Stretch
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExitLength
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ConeExpansion
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ConeFade
+					value = 2.57677674
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 0.396427184
+				}
+				FLOAT
+				{
+					floatName = _ExitStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ConeFadeStart
+					value = 0.317141742
+				}
+				FLOAT
+				{
+					floatName = _Smoothness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Asymmetry
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _LengthBrightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 30.7320404
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-volumetric-cones(Clone)
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 0 0 0
+				key = 0.7 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 0 0 0
+				key = 0.7 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-volumetric-cones(Clone)
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = tBrightness
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.25 0 0 0
+				key = 0.3 0.6 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Waterfall/FX/fx-volumetric-cones(Clone)
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 1
+			name = aBrightness
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Smoothness
+			controllerName = random
+			transformName = Waterfall/FX/fx-volumetric-cones(Clone)
+			useRandomness = False
+			randomnessController = RandomnessController
+			randomnessScale = 0.00999999978
+			name = rShockSmoothness
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.1 0 0
+				key = 1 0.4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _ConeLength
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-volumetric-cones(Clone)
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = -0.5
+			name = tShockLength
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.2 0 0
+				key = 1 0.05 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = plumeInner
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.5
+			rotationOffset = -90,0,0
+			scaleOffset = 0.200000003,20,0.200000003
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.811764717,0.170575857,0.0802657455,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.223529384,0.305668533,0.97647059,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0.594640791
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.11397282
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 10
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 4.50446606
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 6.72349358
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.38156116
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 25
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.396427184
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 2.20023298
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Symmetry
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SymmetryStrength
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0.069374755
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 10
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _TintFalloff
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tTintFalloff
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.2 0.1 0 0
+				key = 0.5 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Noise
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tNoise
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 1 4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = tBrightness
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.2 0 0 0
+				key = 0.3 0.3 0 0
+				key = 0.8 0.6 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = engineOn
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = engineOn
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			floatName = _Brightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = aBrightness
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+}
+

--- a/GameData/WaterfallRestock/Templates/waterfall-jet-standard-1.cfg
+++ b/GameData/WaterfallRestock/Templates/waterfall-jet-standard-1.cfg
@@ -1,0 +1,252 @@
+// Standard jet engine template. Use for most kinds of modern air-breathing engines
+// Employed by Juno, Wheesley, Goliath
+// 
+// Supported controllers:
+//  - [atmosphereDepth] Atmosphere Density
+//  - [random] Randomness
+//  - [mach] Mach
+//  - [throttle] Throttle
+//  - [engineOn] Engine On State
+//  - [reverser] Scalar Module (AnimateGeneric)
+// 
+// by Kavaeric
+EFFECTTEMPLATE
+{
+	templateName = waterfall-jet-standard-1
+	EFFECT
+	{
+		name = distort
+		parentName = smokePoint
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0, 0, 0
+			rotationOffset = -90, 0, 0
+			scaleOffset = 1, 3, 1
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Distortion (Dynamic) //Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _DistortionTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Blur
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Swirl
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Highlight
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Strength
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 10
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 80
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 80
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.287409723
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 1.0
+				}
+			}
+		}
+
+		// Increases the strength of the distortion as throttle increases
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = throttleStrength
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.1 0 0
+				key = 1 0.3 0 0
+			}
+		}
+		// Increases the length of the trail as throttle increases
+		SCALEMODIFIER
+		{
+			controllerName = throttle
+			transformName = Cylinder
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.05
+			name = throttleScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 4 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
+		// Disables the effect entirely when the engine is off or flamed out
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = engineOn
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = engineOn
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		// Reduces the strength of the effect as the air gets thinner
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = atmoStrength
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		// Reduces the strength of the effect as speed increases
+		FLOATMODIFIER
+		{
+			floatName = _Strength
+			controllerName = mach
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = machFadeOut
+			combinationType = MULTIPLY
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 1 0 0 0
+			}
+		}
+		// Flips the effect's direction upon reverser deployment
+		SCALEMODIFIER
+		{
+			controllerName = reverser
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = reverserScale
+			combinationType = MULTIPLY
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 -0.3 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		// Flares the effect cone upon reverser deployment
+		FLOATMODIFIER
+		{
+			floatName = _ExpandLinear
+			controllerName = reverser
+			transformName = Cylinder
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			name = reverserScale
+			combinationType = REPLACE
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 2 0 0
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added Waterfall configs for the following engines:

- LV-TX87 "Bobcat" Liquid Fuel Engine (Making History 1.875m lifter)
- LV-T91 "Cheetah" Liquid Fuel Engine (Making History 1.875 vacuum)
- Mk-55 "Thud" Liquid Fuel Engine
- T-1 Toroidal Aerospike "Dart" Liquid Fuel Engine
- J-20 "Juno" Basic Jet Engine
- J-33 "Wheesley" Turbofan Engine
- J-90 "Goliath" Turbofan Engine
- J-404 "Panther" Afterburning Turbofan
- J-X4 "Whiplash" Turbo Ramjet Engine

Jet engines use new templates located in `WaterfallRestock/Templates`.

<img width="640" alt="KSP_x64_Dt0aJm0YfK" src="https://github.com/user-attachments/assets/00d0fe5d-8851-4fc7-95bf-db2ca919d759" />

<img width="640" alt="vlc_eZoWCgRjhk" src="https://github.com/user-attachments/assets/7a2930cb-dbc7-4fee-9867-0bff3cfaf202" />

